### PR TITLE
Set discord.boats as defunct

### DIFF
--- a/data/lists/discord.boats.json
+++ b/data/lists/discord.boats.json
@@ -6,7 +6,7 @@
     "icon": "https://cdn.discordapp.com/icons/439866052684283905/a_50718fbcb8030a76b775540db66bd0b8.png",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 1,
     "description": "A growing directory of Discord bots to enhance your server - Find the perfect bot for your needs and add it to your server easily, quickly and for free.",
     "api_docs": "https://docs.discord.boats/",


### PR DESCRIPTION
The discord.boats website and API will stop working on Wednesday. No actual timeframe was given tho. So this PR should probably only be merged after that day.

Related message ([Message Link](https://discord.com/channels/439866052684283905/439872382430347264/945079542790357024)):
![image](https://user-images.githubusercontent.com/11576465/155231324-f12d9c2c-25b8-4267-9283-0a0d01f7b054.png)
