### PR TITLE
Update discord.rovelstars.com display

### DIFF
--- a/data/lists/discord.rovelstars.com.json
+++ b/data/lists/discord.rovelstars.com.json
@@ -5,7 +5,7 @@
     "url": "https://discord.rovelstars.com",
     "icon": "https://discord.rovelstars.com/assets/img/bot/logo.svg",
     "language": "English",
-    "display": 1,
+    "display": 0,
     "defunct": 0,
     "discord_only": 1,
     "description": "Imagine a place - where you get to find everything about discord! Ranging from bots, to users, servers, templates, banners, stickers and emojis!",


### PR DESCRIPTION
This list has been using anti-consumer and privacy invasive practices and should be hidden from botblock for now.

The owner has aknowledged at one point they were logging user ips for users that login to a discord channel which the owner has said he removed, scraping data from other botlist and adding bots to his list without the bot owners consent and various other stuff that has been discussed.