### PR TITLE
Change botlists to defunct

### DIFF
--- a/data/lists/bladelist.gg.json
+++ b/data/lists/bladelist.gg.json
@@ -7,7 +7,7 @@
     "icon": "https://cdn.discordapp.com/icons/645281161949741064/fad8d2e250d653f180a547f728273f5a.png",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 1,
     "description": "Discover a lot of new Discord bots for free and without login ! we check your bot in less than 12h* ",
     "api_docs": "https://docs.bladelist.gg/",

--- a/data/lists/botlist.co.json
+++ b/data/lists/botlist.co.json
@@ -7,7 +7,7 @@
     "icon": "https://botlist.co/images/BotList_logo.svg",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 0,
     "description": null,
     "api_docs": null,

--- a/data/lists/bots.discordlabs.org.json
+++ b/data/lists/bots.discordlabs.org.json
@@ -7,7 +7,7 @@
     "icon": "https://cdn.discordapp.com/icons/608711879858192479/a_d25bd6131772dd5f7018ffb8951f115c.png",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 1,
     "description": "Bump up your servers's street cred by finding some great bots here!",
     "api_docs": "https://docs.discordlabs.org/",

--- a/data/lists/bots.ondiscord.xyz.json
+++ b/data/lists/bots.ondiscord.xyz.json
@@ -7,7 +7,7 @@
     "icon": "https://cdn.discordapp.com/icons/446425626988249089/c9599b1e0fdb902b81d93468ada512cf.png",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 1,
     "description": "Easily find and share Discord bots",
     "api_docs": "https://bots.ondiscord.xyz/info/api",

--- a/data/lists/carbonitex.net.json
+++ b/data/lists/carbonitex.net.json
@@ -7,7 +7,7 @@
     "icon": "https://cdn.discordapp.com/icons/112319935652298752/633a48b3446045ceed222a32622a9dbd.png",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 1,
     "description": null,
     "api_docs": null,

--- a/data/lists/discordbots.co.json
+++ b/data/lists/discordbots.co.json
@@ -7,7 +7,7 @@
     "icon": "https://discordbots.co/favicon.png",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 1,
     "description": "A new well-developed bot list from Vultrex Development. Here you can advertise your bot for free! ",
     "api_docs": "https://discordbots.co/api",

--- a/data/lists/discordlistology.com.json
+++ b/data/lists/discordlistology.com.json
@@ -7,7 +7,7 @@
     "icon": "https://cdn.discordapp.com/icons/658262945234681856/e0a8d8ff2b3d27c0c76893a1ba40d571.png",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 1,
     "description": "Start listing your Discord bots & servers for free!",
     "api_docs": "https://discordlistology.com/developer/documentation",

--- a/data/lists/discordz.gg.json
+++ b/data/lists/discordz.gg.json
@@ -7,7 +7,7 @@
     "icon": "https://cdn.discordz.gg/img/logo.png",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 1,
     "description": "Spice up your discord experience with our range of bots and servers!",
     "api_docs": "https://docs.discordz.gg",

--- a/data/lists/thereisabotforthat.com.json
+++ b/data/lists/thereisabotforthat.com.json
@@ -7,7 +7,7 @@
     "icon": "https://pbs.twimg.com/app_img/834705925562851330/CjvLy-YN?format=png&name=73x73",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 0,
     "description": null,
     "api_docs": null,

--- a/data/lists/vitallist.xyz.json
+++ b/data/lists/vitallist.xyz.json
@@ -7,7 +7,7 @@
     "icon": "https://vitallist.xyz/img/icon.webp",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 1,
     "description": "A place where you can find Discord bots, Vital List.|",
     "api_docs": "https://vitallist.xyz/docs/",

--- a/data/lists/wonderbotlist.com.json
+++ b/data/lists/wonderbotlist.com.json
@@ -7,7 +7,7 @@
     "icon": "https://cdn.discordapp.com/icons/501017909389295616/b612c45b809314e5e362dd8fa87bb3ac.png",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 1,
     "description": null,
     "api_docs": "https://api.wonderbotlist.com/en/",

--- a/data/lists/yabl.xyz.json
+++ b/data/lists/yabl.xyz.json
@@ -7,7 +7,7 @@
     "icon": "https://i.imgur.com/OFiMern.png",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 1,
     "description": null,
     "api_docs": "https://yabl.xyz/api",


### PR DESCRIPTION
I went through every bot list and double checked if it was still approving bots or not, and set defunct as necessary. Reasoning for each list is attached to the commit.