### PR TITLE
Update discordextremelist.xyz owners

### DIFF
--- a/data/lists/discordextremelist.xyz.json
+++ b/data/lists/discordextremelist.xyz.json
@@ -22,7 +22,7 @@
     "view_bot": "https://discordextremelist.xyz/bots/:id",
     "bot_widget": null,
     "content": null,
-    "owners": "advaith#9121 (190916650143318016), Cairo#1123 (208105877838888960), Ice#4710 (302604426781261824)",
+    "owners": "@advaith (190916650143318016), @carolinaisslaying (1100295355800748073), @winterfoxxo (302604426781261824)",
     "discord": "https://discord.gg/WeCer3J",
     "features": [
         "bot-resubmission",

--- a/data/lists/discordextremelist.xyz.json
+++ b/data/lists/discordextremelist.xyz.json
@@ -22,7 +22,7 @@
     "view_bot": "https://discordextremelist.xyz/bots/:id",
     "bot_widget": null,
     "content": null,
-    "owners": "@advaith (190916650143318016), @carolinaisslaying (1100295355800748073), @winterfoxxo (302604426781261824)",
+    "owners": "advaith#0000 (190916650143318016), carolinaisslaying#0000 (1100295355800748073), winterfoxxo#0000 (302604426781261824)",
     "discord": "https://discord.gg/WeCer3J",
     "features": [
         "bot-resubmission",


### PR DESCRIPTION
Updates DEL's ownership information to include my updated account, as well as switch the rest of the owner's of DEL to their new usernames (per Discord's new username formatting)