### PR TITLE
Update guardianbots.xyz + topcord.xyz defunct flag

### DIFF
--- a/data/lists/guardianbots.xyz.json
+++ b/data/lists/guardianbots.xyz.json
@@ -7,7 +7,7 @@
     "icon": "https://cdn.guardianbots.xyz/uploads/logo.png",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 1,
     "description": "Discover hundreds of Discord bots and add your own to make it popular",
     "api_docs": null,

--- a/data/lists/topcord.xyz.json
+++ b/data/lists/topcord.xyz.json
@@ -7,7 +7,7 @@
     "icon": "https://topcord.xyz/logo.png",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 0,
     "description": "TopCord is the best Discord Bot List for finding the Discord bots that suit your server.",
     "api_docs": "https://docs.topcord.xyz/#/",


### PR DESCRIPTION
I've gone through and marked two bot lists as defunct. The reasoning for why are in the commit messages for both bot lists.