### PR TITLE
Update discord.place owners + features

### DIFF
--- a/data/lists/discord.place.json
+++ b/data/lists/discord.place.json
@@ -22,7 +22,7 @@
     "view_bot": "https://discord.place/bots/:id",
     "bot_widget": null,
     "content": null,
-    "owners": "@ben.can#0000 (957840712404193290)",
+    "owners": "@skyhancloud#0000 (957840712404193290)",
     "discord": "https://invite.discord.place",
     "features": [
         "additional-bot-owners-editors",

--- a/data/lists/discord.place.json
+++ b/data/lists/discord.place.json
@@ -39,6 +39,7 @@
         "offers-paid-promotion",
         "requires-owner-in-server",
         "votes-sent-to-webhooks",
-        "voting-data-exposed"
+        "voting-data-exposed",
+        "iframe-long-description"
     ]
 }


### PR DESCRIPTION
Bot long descriptions recently got iframe support at discord.place.

This pull request includes a small change to the `data/lists/discord.place.json` file. The change adds a new feature identifier to the list of features for the Discord place.

* [`data/lists/discord.place.json`](diffhunk://#diff-355573ca4d9602c1f0b1ca03fc6192f1089cb5423b0d4278db379f6a7d791f28L42-R43): Added the "iframe-long-description" feature identifier to the list of features.