### PR TITLE
Update discord-botlist.eu defunct flag

### DIFF
--- a/data/lists/discord-botlist.eu.json
+++ b/data/lists/discord-botlist.eu.json
@@ -7,7 +7,7 @@
     "icon": "https://discord-botlist.eu/pics/logo.jpg",
     "language": "English",
     "display": 1,
-    "defunct": 0,
+    "defunct": 1,
     "discord_only": 1,
     "description": "discord-botlist.eu offers a wide variety of bots for your personal needs. Find your bot today!",
     "api_docs": "https://docs.discord-botlist.eu",


### PR DESCRIPTION
This pull request makes a minor update to the `data/lists/discord-botlist.eu.json` file, marking the `discord-botlist.eu` service as defunct. The site has a farewell message since 2025-05-17.